### PR TITLE
fix gdb cc cmd

### DIFF
--- a/ext_ida/SyncPlugin.py
+++ b/ext_ida/SyncPlugin.py
@@ -329,7 +329,7 @@ class RequestHandler(object):
     # return current cursor in IDA Pro
     def req_cursor(self, hash):
         print("[*] request IDA Pro cursor position")
-        addr = idc.ScreenEA()
+        addr = self.rebase_remote(idc.ScreenEA())
         self.notice_broker("cmd", "\"cmd\":\"%s\"" % addr)
         return
 


### PR DESCRIPTION
Error occurs when the `remote_base` is not equal to the `local_base`. Call `self.remote_base()` first before sending current cursor in IDA Pro to remote gdb.